### PR TITLE
Switched log message from f-string to deferred formatting for performance

### DIFF
--- a/x_robots_tag_middleware/middleware.py
+++ b/x_robots_tag_middleware/middleware.py
@@ -18,6 +18,6 @@ class XRobotsTagMiddleware(object):
 
         if settings.X_ROBOTS_TAG:
             response["X-Robots-Tag"] = ",".join(settings.X_ROBOTS_TAG)
-            logger.debug(f"x_robots_tag: {settings.X_ROBOTS_TAG}")
+            logger.debug("x_robots_tag: %s", settings.X_ROBOTS_TAG)
 
         return response


### PR DESCRIPTION
There's an [optimization suggestion](https://docs.python.org/3/howto/logging.html#optimization) to defer string formatting in log messages by passing the values to be interpolated as arguments. Not a big deal for this simple "string into string" (though since this is middleware we expect it be called _a lot_ ... so we can save a few ticks).